### PR TITLE
updated copyright year to 2022

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -70,7 +70,7 @@ master_doc = 'content/index'
 
 # General information about the project.
 project = 'OTOBO Installation Guide'
-copyright = '2019-2020 Rother OSS GmbH, https://otobo.de/'
+copyright = '2019-2022 Rother OSS GmbH, https://otobo.de/'
 author = 'Rother OSS GmbH'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/content/index.rst
+++ b/content/index.rst
@@ -9,7 +9,7 @@ OTOBO Installation Tutorial
 This work is copyrighted by OTRS AG (https://otrs.com),
 Zimmersmühlenweg 11, 61440 Oberursel, Germany.
 
-Copyright © for modifications and amendments 2019-2020 ROTHER OSS GmbH
+Copyright © for modifications and amendments 2019-2022 ROTHER OSS GmbH
 (https://otobo.de), Oberwalting 31, 94339 Leiblfing, Germany
 
 Terms and Conditions OTRS:

--- a/documentation.yml
+++ b/documentation.yml
@@ -12,7 +12,7 @@ Variables:
 
 # project meta information
 ProjectName: OTOBO Installation Guide
-Copyright: 2019-2020 Rother OSS GmbH, https://otobo.de/
+Copyright: 2019-2022 Rother OSS GmbH, https://otobo.de/
 Author: Rother OSS GmbH
 Version: 10.0
 Release: 10.0


### PR DESCRIPTION
Since the copyright notice is on the bottom of every documentation page, this can be misleading and make people think the docs are not up-to-date anymore or the project is stale. To save us some work, I decided to bump it directly to 2022.