### PR TITLE
Replace docker exec by docker-compose exec

### DIFF
--- a/content/installation-docker.rst
+++ b/content/installation-docker.rst
@@ -185,7 +185,7 @@ Run the OTOBO installer at http://yourIPorFQDN/otobo/installer.pl.
 .. note::
 
     To change to the OTOBO directory, inside the running container, to work on command line as usual, you can use the following Docker command:
-    ``docker exec -it otobo_web_1 bash``.
+    ``docker-compose exec web bash``.
 
 Additional technical information
 ----------------------------------
@@ -508,13 +508,13 @@ running the test suite on a fresh installation.
 
    docker_admin> docker-compose down -v
    docker_admin> docker-compose up --detach
-   docker_admin> docker stop otobo_daemon_1
-   docker_admin> docker exec -t --user otobo otobo_web_1 bash\
+   docker_admin> docker-compose stop daemon
+   docker_admin> docker-compose exec web bash\
    -c "rm -f Kernel/Config/Files/ZZZAAuto.pm ; bin/docker/quick_setup.pl --db-password otobo_root"
-   docker_admin> docker exec -t --user otobo otobo_web_1 bash\
+   docker_admin> docker-compose exec web bash\
    -c "bin/docker/run_test_suite.sh"
    .......
-   docker_admin> docker start otobo_daemon_1
+   docker_admin> docker-compose start daemon
 
 List of useful commands
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -541,6 +541,7 @@ List of useful commands
 
 * ``docker-compose config`` check and show the configuration
 * ``docker-compose ps`` show the running containers
+* ``docker-compose exec nginx nginx -s reload`` reload nginx
 
 Resources
 ----------------------------------

--- a/content/migration-from-otrs-6.rst
+++ b/content/migration-from-otrs-6.rst
@@ -347,11 +347,12 @@ Note that the password for the database root is now the password that has been s
 
 .. code-block:: bash
 
+    docker_admin> cd /opt/otobo-docker
     docker_admin> cd <dump_dir>
-    docker_admin> docker exec -i otobo_db_1 mysql -u root -p<root_secret> otobo < otrs_pre.sql
-    docker_admin> docker exec -i otobo_db_1 mysql -u root -p<root_secret> otobo < otrs_schema_for_otobo.sql
-    docker_admin> docker exec -i otobo_db_1 mysql -u root -p<root_secret> otobo < otrs_post.sql
-    docker_admin> docker exec -i otobo_db_1 mysql -u root -p<root_secret> otobo < otrs_data.sql
+    docker_admin> docker-compose exec -T db mysql -u root -p<root_secret> otobo < <dump_dir>/otrs_pre.sql
+    docker_admin> docker-compose exec -T db mysql -u root -p<root_secret> otobo < <dump_dir>/otrs_schema_for_otobo.sql
+    docker_admin> docker-compose exec -T db mysql -u root -p<root_secret> otobo < <dump_dir>/otrs_post.sql
+    docker_admin> docker-compose exec -T db mysql -u root -p<root_secret> otobo < <dump_dir>/otrs_data.sql
 
 For a quick check whether the import worked, you can run the following commands.
 
@@ -365,9 +366,9 @@ or
 
 .. code-block:: bash
 
-    docker_admin> docker exec -i otobo_db_1 mysql -u root -p<root_secret> -e 'SHOW DATABASES'
-    docker_admin> docker exec -i otobo_db_1 mysql -u root -p<root_secret> otobo -e 'SHOW TABLES'
-    docker_admin> docker exec -i otobo_db_1 mysql -u root -p<root_secret> otobo -e 'SHOW CREATE TABLE ticket'
+    docker_admin> docker-compose exec -T db mysql -u root -p<root_secret> -e 'SHOW DATABASES'
+    docker_admin> docker-compose exec -T db mysql -u root -p<root_secret> otobo -e 'SHOW TABLES'
+    docker_admin> docker-compose exec -T db mysql -u root -p<root_secret> otobo -e 'SHOW CREATE TABLE ticket'
 
 The database is now migrated. This means that during the next step we can skip the database migration.
 Watch out for the relevant checkbox.


### PR DESCRIPTION
As pointed out by @bschmalhofer in #89, there were still references to `docker exec` in the install docs. 
This should be fixed now.