### PR TITLE
Issue rotheross/otobo#1504: update Docker image labels

### DIFF
--- a/content/backup-restore-docker.rst
+++ b/content/backup-restore-docker.rst
@@ -41,7 +41,7 @@ This means that the webserver and the OTOBO daemon may, but don't have to, be st
 .. code-block:: bash
 
     # create a backup
-    docker_admin>docker run -it --rm --volume otobo_opt_otobo:/opt/otobo --volume otobo_backup:/otobo_backup --network otobo_default rotheross/otobo:latest scripts/backup.pl -d /otobo_backup
+    docker_admin>docker run -it --rm --volume otobo_opt_otobo:/opt/otobo --volume otobo_backup:/otobo_backup --network otobo_default rotheross/otobo:latest-10_0 scripts/backup.pl -d /otobo_backup
 
     # check the backup file
     docker_admin>tree otobo_backup
@@ -72,4 +72,4 @@ The placeholder ``<TIMESTAMP>`` is something like ``2020-09-07_09-38``.
 .. code-block:: bash
 
     # restore a backup
-    docker_admin>docker run -it --rm --volume otobo_opt_otobo:/opt/otobo --volume otobo_backup:/otobo_backup --network otobo_default rotheross/otobo:latest scripts/restore.pl -d /opt/otobo -b /otobo_backup/<TIMESTAMP>
+    docker_admin>docker run -it --rm --volume otobo_opt_otobo:/opt/otobo --volume otobo_backup:/otobo_backup --network otobo_default rotheross/otobo:latest-10_0 scripts/restore.pl -d /opt/otobo -b /otobo_backup/<TIMESTAMP>

--- a/content/backup-restore.rst
+++ b/content/backup-restore.rst
@@ -112,7 +112,7 @@ This means that the webserver and the Daemon may, but don't have to, be stopped.
 .. code-block:: bash
 
     # create a backup
-    docker_admin> docker run -it --rm --volume otobo_opt_otobo:/opt/otobo --volume otobo_backup:/otobo_backup --network otobo_default rotheross/otobo:latest scripts/backup.pl -d /otobo_backup
+    docker_admin> docker run -it --rm --volume otobo_opt_otobo:/opt/otobo --volume otobo_backup:/otobo_backup --network otobo_default rotheross/otobo:latest-10_0 scripts/backup.pl -d /otobo_backup
 
     # check the backup file
     docker_admin> tree otobo_backup
@@ -123,4 +123,4 @@ The placeholder ``<TIMESTAMP>`` is something like ``2020-09-07_09-38``.
 .. code-block:: bash
 
     # create a backup
-    docker_admin> docker run -it --rm --volume otobo_opt_otobo:/opt/otobo --volume otobo_backup:/otobo_backup --network otobo_default rotheross/otobo:latest scripts/restore.pl -d /opt/otobo -b /otobo_backup/<TIMESTAMP>
+    docker_admin> docker run -it --rm --volume otobo_opt_otobo:/opt/otobo --volume otobo_backup:/otobo_backup --network otobo_default rotheross/otobo:latest-10_0 scripts/restore.pl -d /opt/otobo -b /otobo_backup/<TIMESTAMP>

--- a/content/installation-docker.rst
+++ b/content/installation-docker.rst
@@ -359,7 +359,7 @@ First comes generation of the new volume. In these sample commands, we use the e
     docker_admin> ls $otobo_nginx_custom_config_mp    # another sanity check
 
     # copy the default config into the new volume
-    docker_admin> docker create --name tmp-nginx-container rotheross/otobo-nginx-webproxy:latest  # use the appropriate label
+    docker_admin> docker create --name tmp-nginx-container rotheross/otobo-nginx-webproxy:latest-10_0  # or latest-10_1, use the appropriate label
     docker_admin> docker cp tmp-nginx-container:/etc/nginx/templates/otobo_nginx.conf.template $otobo_nginx_custom_config_mp # might need 'sudo'
     docker_admin> ls -l $otobo_nginx_custom_config_mp/otobo_nginx.conf.template # just checking, might need 'sudo'
     docker_admin> docker rm tmp-nginx-container
@@ -534,7 +534,7 @@ List of useful commands
 * ``docker volume inspect --format '{{ .Mountpoint }}' otobo_nginx_ssl`` get volume mountpoint
 * ``docker volume rm tmp_volume`` remove a volume
 * ``docker inspect <container>`` inspect a container
-* ``docker save --output otobo.tar otobo:latest && tar -tvf otobo.tar`` list files in an image
+* ``docker save --output otobo.tar otobo:latest-10_0 && tar -tvf otobo.tar`` list files in an image
 * ``docker exec -it nginx-server nginx -s reload`` reload nginx
 
 **Docker Compose**

--- a/content/updating-docker.rst
+++ b/content/updating-docker.rst
@@ -63,7 +63,7 @@ Docker compose can be used for fetching the wanted images from https://hub.docke
     # Change to the otobo docker directory
     docker_admin> cd /opt/otobo-docker
 
-    # fetch the new images, either 'latest' or the specific version declared in .env
+    # fetch the new images, either 'latest-10_0' or 'latest-10_1' or the specific version declared in .env
     docker_admin> docker-compose pull
 
 Update OTOBO


### PR DESCRIPTION
'latest' becomes either 'latest-10_0' or 'latest-10_1'.
But use 'latest-10_0' in most sample commands, for simplicity's sake