### PR TITLE
Changed GitHub Link

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -141,8 +141,8 @@ html_copy_source = False
 
 html_context = {
     "display_github": True,
-    "github_user": "OTOBO",
-    "github_repo": "doc-installation",
+    "github_user": "RotherOSS",
+    "github_repo": "doc-otobo-installation",
     "github_version": "master",
     "conf_py_path": "/",
 }


### PR DESCRIPTION
The  'Edit on GitHub' in the top-right corner is not generated correctly.

Changed from:
https://github.com/OTOBO/doc-installation/blob/master/content/index.rst
to
https://github.com/RotherOSS/doc-otobo-installation/blob/master/content/index.rst