### PR TITLE
Fix Issue #1863 in otobo-repository

### DIFF
--- a/content/migration-from-otrs-6.rst
+++ b/content/migration-from-otrs-6.rst
@@ -633,3 +633,7 @@ Stop the webserver for otobo, so that the DB connection for otobo is closed.
 5. Start the web server for otobo again
 
 6. Proceed with step 5, that is with running ``migration.pl``.
+
+.. note::
+
+    If migrating to OTOBO version greater or equal 10.1 the script ``/opt/otobo/scripts/DBUpdate-to-10.1.pl`` has to be executed, to create the tables ``stats_report`` & ``data_storage``, which were newly added in version 10.1.


### PR DESCRIPTION
Adds a note to execute the DBUpdate-script, if migrating from Oracle to Oracle for OTOBO version 10.1 or higher, since 2 tables are not created automatically.

This fixes the [issue #1863 in the otobo-repository](https://github.com/RotherOSS/otobo/issues/1863).
