### PR TITLE
doc: Update updating-docker.rst to hint ITSM migration script for 11.0.x

### DIFF
--- a/content/updating-docker.rst
+++ b/content/updating-docker.rst
@@ -118,3 +118,11 @@ For minor and major version upgrades, prior to this also update tasks for the co
 
         docker_admin> ./scripts/update.sh --help
         docker_admin> ./scripts/update.sh
+
+.. note::
+
+    When upgrading from 10.1.x to 11.0.x with the ITSM plugin installed, the following command has to be executed additionally:
+
+    .. code-block:: bash
+
+        docker exec -it otobo_web_1 perl bin/otobo.Console.pl Admin::ITSM::Configitem::UpgradeTo11


### PR DESCRIPTION
This took some time to troubleshoot, so it would be great to offer it directly in the documentation.

Not executing that will leave an ITSM enabled upgraded Otobo installation kinda broken.