### PR TITLE
Update content/installation.rst - Step 1: Unpack and Install OTOBO

### DIFF
--- a/content/installation.rst
+++ b/content/installation.rst
@@ -65,7 +65,7 @@ Unpack the source archive (for example, using ``tar``) into the directory ``/opt
 
     root> mkdir /opt/otobo-install && mkdir /opt/otobo                      # Create a temporary install directory
     root> cd /opt/otobo-install                                             # Change into the update directory
-    root> wget https://ftp.otobo.org/pub/otobo/otobo-latest-11.0.tar.gz     # Download he latest OTOBO 10 release
+    root> wget https://ftp.otobo.org/pub/otobo/otobo-latest-11.0.tar.gz     # Download the latest OTOBO 10 release
     root> tar -xzf otobo-latest-11.0.tar.gz                                 # Unzip OTOBO
     root> cp -r otobo-11.x.x/* /opt/otobo                                   # Copy the new otobo directory to /opt/otobo
 

--- a/content/installation.rst
+++ b/content/installation.rst
@@ -66,7 +66,7 @@ Unpack the source archive (for example, using ``tar``) into the directory ``/opt
     root> mkdir /opt/otobo-install && mkdir /opt/otobo                          # Create a temporary install directory
     root> cd /opt/otobo-install                                                 # Change into the update directory
     root> wget https://ftp.otobo.org/pub/otobo/otobo-latest-11.0.tar.gz         # Download the latest OTOBO 10 release
-    root> tar -xzf otobo-latest-11.0.tar.gz --strip-components=1 -C /opt/otobo/ # Unzip OTOBO to /opt/otobo
+    root> tar -xzf otobo-latest-11.0.tar.gz --strip-components=1 -C /opt/otobo  # Unzip OTOBO to /opt/otobo
 
 
 Step 2: Install Additional Programs and Perl Modules

--- a/content/installation.rst
+++ b/content/installation.rst
@@ -67,7 +67,7 @@ Unpack the source archive (for example, using ``tar``) into the directory ``/opt
     root> cd /opt/otobo-install                                             # Change into the update directory
     root> wget https://ftp.otobo.org/pub/otobo/otobo-latest-11.0.tar.gz     # Download he latest OTOBO 10 release
     root> tar -xzf otobo-latest-11.0.tar.gz                                 # Unzip OTOBO
-    root> cp -r otobo-10.x.x/* /opt/otobo                                     # Copy the new otobo directory to /opt/otobo
+    root> cp -r otobo-11.x.x/* /opt/otobo                                   # Copy the new otobo directory to /opt/otobo
 
 
 Step 2: Install Additional Programs and Perl Modules

--- a/content/installation.rst
+++ b/content/installation.rst
@@ -63,11 +63,10 @@ Unpack the source archive (for example, using ``tar``) into the directory ``/opt
 
 .. code-block:: bash
 
-    root> mkdir /opt/otobo-install && mkdir /opt/otobo                      # Create a temporary install directory
-    root> cd /opt/otobo-install                                             # Change into the update directory
-    root> wget https://ftp.otobo.org/pub/otobo/otobo-latest-11.0.tar.gz     # Download the latest OTOBO 10 release
-    root> tar -xzf otobo-latest-11.0.tar.gz                                 # Unzip OTOBO
-    root> cp -r otobo-11.x.x/* /opt/otobo                                   # Copy the new otobo directory to /opt/otobo
+    root> mkdir /opt/otobo-install && mkdir /opt/otobo                          # Create a temporary install directory
+    root> cd /opt/otobo-install                                                 # Change into the update directory
+    root> wget https://ftp.otobo.org/pub/otobo/otobo-latest-11.0.tar.gz         # Download the latest OTOBO 10 release
+    root> tar -xzf otobo-latest-11.0.tar.gz --strip-components=1 -C /opt/otobo/ # Unzip OTOBO to /opt/otobo
 
 
 Step 2: Install Additional Programs and Perl Modules


### PR DESCRIPTION
The `content/installation.rst` still points to version `10`.

I also may ask if a shorter version may would be an option?
This extracts the `otobo-latest-11.0.tar.gz` directly into `/opt/otobo` without an additional `cp`

The block
```
    root> wget https://ftp.otobo.org/pub/otobo/otobo-latest-11.0.tar.gz     # Download he latest OTOBO 10 release
    root> tar -xzf otobo-latest-11.0.tar.gz                                 # Unzip OTOBO
    root> cp -r otobo-11.x.x/* /opt/otobo                                   # Copy the new otobo directory to /opt/otobo
```
could be replaced by 
```
    root> wget https://ftp.otobo.org/pub/otobo/otobo-latest-11.0.tar.gz           # Download the latest OTOBO 10 release
    root> tar -xzf otobo-latest-11.0.tar.gz --strip-components=1 -C /opt/otobo/   # Unzip OTOBO to /opt/otobo
```